### PR TITLE
README.md and mysmb.py are updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This allows for this version of the MS17-010 exploit to be a bit more flexible, 
 
 Included is also an enternal blue checker script that allows you to test if your target is potentially vulnerable to MS17-010
 
-run `python eternalblue_checker.py <TARGET-IP>`
+run `python eternal_checker.py <TARGET-IP>`
 
 
 ## TODO:

--- a/mysmb.py
+++ b/mysmb.py
@@ -564,7 +564,7 @@ class SMBServer(Thread):
         logging.info('Creating tmp directory')
         try:
             os.mkdir(SMBSERVER_DIR)
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
         logging.info('Setting up SMB Server')


### PR DESCRIPTION
TL;DR  
In `README.md` the code is suggested run as follows `python eternalblue_checker.py <TARGET-IP>` however the file name is `eternal_checker.py`. So I updated `README.md` according to the requirement.

The second one is related to the try-exception block in `mysmb.py` to create `SMBSERVER_DIR`. If the code runs with python3.x, can't be compiled because of the syntax is not fit to **Python3.x** format. So I fix that line as well and it runs with both **Python3.x** and **Python2.x** in this way.

