### PR TITLE
Avoid exceptions when decoding umlauts

### DIFF
--- a/mysmb.py
+++ b/mysmb.py
@@ -474,7 +474,7 @@ class RemoteShell(cmd.Cmd):
         self.execute_remote('cd ' )
         if len(self.__outputBuffer) > 0:
             # Stripping CR/LF
-            self.prompt = self.__outputBuffer.decode().replace('\r\n','') + '>'
+            self.prompt = self.__outputBuffer.decode(errors='replace').replace('\r\n','') + '>'
             self.__outputBuffer = b''
 
     def do_CD(self, s):
@@ -519,7 +519,7 @@ class RemoteShell(cmd.Cmd):
 
     def send_data(self, data):
         self.execute_remote(data)
-        print(self.__outputBuffer.decode())
+        print(self.__outputBuffer.decode(errors='replace'))
         self.__outputBuffer = b''
 
 class SMBServer(Thread):


### PR DESCRIPTION
With `errors='replace'`, the function won't throw an exception when encountering utf-8 errors. Not sure what the correct encoding is. I would have though `utf-16-le`, but that does not seem to be the case.